### PR TITLE
ET-4636 fix action typo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@ve407df249e6c155d03c0e4375f34bc2385f52d65 # v1.6.1
+        uses: aws-actions/amazon-ecr-login@e407df249e6c155d03c0e4375f34bc2385f52d65 # v1.6.1
   
       - name: docker push
         id: docker-push


### PR DESCRIPTION
**Reference**

- [ET-4636]
- #15

**Summary**

- remove the leading `v` from the version hash